### PR TITLE
The -e command now accepts an argument…

### DIFF
--- a/oooenv/cli/main.py
+++ b/oooenv/cli/main.py
@@ -210,10 +210,10 @@ def _args_cmd_global(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "-e",
         "--editable",
-        help="Install a project in editable mode from the local project path. Similar to pip install -e .",
-        action="store_true",
-        dest="editable",
-        default=False,
+        help="Install a project in editable mode from the local project path. Similar to pip install -e <package>. Defaults to . (the current package itself), but the root folder of any package source can be given (relative or absolute).",
+        action="store",
+        dest="editable_package_path",
+        default=".",
     )
 
 
@@ -222,8 +222,8 @@ def _args_action_global(a_parser: argparse.ArgumentParser, args: argparse.Namesp
     if args.show_version:
         # return importlib.metadata.version(__package__ or __name__)
         return importlib.metadata.version("oooenv")
-    if args.editable:
-        if result := install.pip_e():
+    if args.editable_package_path:
+        if result := install.pip_e(args.editable_package_path):
             return result
         else:
             return "Install Failed for unknown reason."

--- a/oooenv/cmds/install.py
+++ b/oooenv/cmds/install.py
@@ -4,7 +4,7 @@ import os
 from ..utils import local_paths
 
 
-def pip_e() -> str:
+def pip_e(package_path='.') -> str:
     """
     Install root path in virtual environment site-packages directory.
 
@@ -14,7 +14,9 @@ def pip_e() -> str:
         str: Message indicating success or failure. Empty string on failure.
     """
     try:
-        root_path = Path(local_paths.get_virtual_env_path()).parent
+        root_path = Path(local_paths.get_virtual_env_path()).parent / package_path
+        if not root_path.exists():
+            return f"No such package path as: {str(root_path)}"
         site_packages_dir = local_paths.get_site_packages_dir()
         if site_packages_dir is None:
             return ""


### PR DESCRIPTION
…  that is the (relative) path of the package source to be installed as editable. Defaults to ".", but could be the root folder of another editable package.

IMPORTANT -- THIS CHANGE IS UNTESTED -- I'm merely submitting this PR as a suggestion. Do with it what you will.

